### PR TITLE
Lotto24 adaptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+/.idea/
+/twilio-live-call-routing.iml

--- a/Splunk-On-Call-Twilio
+++ b/Splunk-On-Call-Twilio
@@ -356,7 +356,7 @@ function teamsMenu (twiml, context, event, payload) {
           )
           .say(
             {voice},
-            `${menuPrompt} ${messages.zeroToRepeat}`
+            `${menuPrompt}    ${messages.zeroToRepeat}`
           );
           // If no response is received from the caller, the call ends
           twiml.say(

--- a/Splunk-On-Call-Twilio
+++ b/Splunk-On-Call-Twilio
@@ -24,13 +24,13 @@ module.exports = {
 // Make changes to messages if you want to modify what is spoken during a call
 // Message keys starting with 'vo' are the text that show up in On-Call timeline alerts
 function handler (context, event, callback) {
-  let {ALERT_HOST, API_HOST, NUMBER_OF_MENUS, voice, NO_VOICEMAIL, NO_CALL} = context;
+  let {ALERT_HOST, API_HOST, NUMBER_OF_MENUS, voice, NO_VOICEMAIL, NO_CALL, GREETING} = context;
   context.NO_CALL = _.isUndefined(NO_CALL)
     ? 'false'
     : NO_CALL.toLowerCase();
   const messages = {
     missingConfig: 'There is a missing configuration value. Please contact your administrator to fix the problem.',
-    greeting: 'Welcome to Splunk Lyve Call Routing.',
+    greeting: _.isUndefined(GREETING) ? 'Welcome to Splunk Lyve Call Routing.' : GREETING,
     menu: 'Please press 1 to reach an on-call representative or press 2 to leave a message.',
     noVMmenu: 'Please press 1 to reach an on-call representative or press 2 to request a callback from the team',
     zeroToRepeat: 'Press zero to repeat this menu.',
@@ -396,14 +396,14 @@ function buildManualTeamList (context) {
         }
       });
 
-      arrayOfTeams.unshift(
+      arrayOfTeams.push(
         {
           name,
           escPolicyName
         }
       );
-      arrayOfTeams.sort((a, b) => (a.name > b.name) ? 1 : -1);
-      arrayOfTeams.reverse();
+      //arrayOfTeams.sort((a, b) => (a.name > b.name) ? 1 : -1);
+      //arrayOfTeams.reverse();
     }
   });
 

--- a/Splunk-On-Call-Twilio
+++ b/Splunk-On-Call-Twilio
@@ -284,6 +284,7 @@ function teamsMenu (twiml, context, event, payload) {
             if (lookupResult.teamExists) {
               return {
                 name: team.name,
+                title: team.title,
                 slug: lookupResult.slug,
                 escPolicyName: team.escPolicyName
               };
@@ -330,7 +331,7 @@ function teamsMenu (twiml, context, event, payload) {
           let menuPrompt = 'Please press';
 
           teamsArray.forEach((team, i, array) => {
-            menuPrompt += ` ${i + 1} for ${team.name}.`;
+            menuPrompt += ` ${i + 1} for ${team.title}.`;
           });
 
           if (NUMBER_OF_MENUS === '1') {
@@ -389,6 +390,7 @@ function buildManualTeamList (context) {
       const name = context[key];
       const keyId = key.substring(4);
       let escPolicyName;
+      let title;
 
       Object.keys(context).forEach((key) => {
         if (key.substring(0, 7).toLowerCase() === 'esc_pol' && key.substring(7) === keyId) {
@@ -396,10 +398,21 @@ function buildManualTeamList (context) {
         }
       });
 
+      Object.keys(context).forEach((key) => {
+        if (key.substring(0, 5).toLowerCase() === 'title' && key.substring(5) === keyId) {
+          title = context[key];
+        }
+      });
+
+      if (!title) {
+        title = name
+      }
+
       arrayOfTeams.push(
         {
           name,
-          escPolicyName
+          escPolicyName,
+          title
         }
       );
       //arrayOfTeams.sort((a, b) => (a.name > b.name) ? 1 : -1);
@@ -407,6 +420,7 @@ function buildManualTeamList (context) {
     }
   });
 
+  log('arrayOfTeams', arrayOfTeams);
   return arrayOfTeams;
 }
 

--- a/Splunk-On-Call-Twilio
+++ b/Splunk-On-Call-Twilio
@@ -341,7 +341,7 @@ function teamsMenu (twiml, context, event, payload) {
           twiml.gather(
             {
               input: 'dtmf',
-              timeout: 5,
+              timeout: 10,
               action: generateCallbackURI(
                 context,
                 {


### PR DESCRIPTION
- the initial greeting message is configurable
- sort teams by number of the key instead of reverse-ASCII sort
- allow to set a TITLE_x env var which is different from the Splunk On-Call team/routing key and use that as spoken name in the menu
- couple of other small adaptions